### PR TITLE
Connection Manager fixes - part 2

### DIFF
--- a/app/app.iml
+++ b/app/app.iml
@@ -65,14 +65,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
@@ -81,6 +73,14 @@
       <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/builds" />

--- a/app/app.iml
+++ b/app/app.iml
@@ -65,14 +65,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
@@ -81,6 +73,14 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/builds" />
@@ -109,7 +109,6 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-support" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/reload-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/restart-dex" />

--- a/app/src/main/java/com/nbusy/app/InstanceManager.java
+++ b/app/src/main/java/com/nbusy/app/InstanceManager.java
@@ -51,14 +51,6 @@ public class InstanceManager extends Application {
         return config;
     }
 
-    public static synchronized void setConfig(Config cfg) {
-        if (cfg == null) {
-            throw new IllegalArgumentException("config cannot be null");
-        }
-
-        config = cfg;
-    }
-
     public static synchronized Worker getWorker() {
         if (worker == null) {
             worker = new Worker(getClient(), getEventBus(), getDB(), getUserProfile());
@@ -86,7 +78,7 @@ public class InstanceManager extends Application {
     public static synchronized Client getClient() {
         if (client == null) {
             if (getConfig().serverUrl != null) {
-                // todo: always use async client otherwise we'll get android.os.NetworkOnMainThreadException, which only happens on TLS mode !
+                // todo: we always have to use async client otherwise we'll get android.os.NetworkOnMainThreadException, which only happens on TLS mode for reasons unknown to me!
                 client = new ClientImpl(getConfig().serverUrl, true);
             } else {
                 client = new ClientImpl(true);

--- a/app/src/main/java/com/nbusy/app/activities/ChatListActivity.java
+++ b/app/src/main/java/com/nbusy/app/activities/ChatListActivity.java
@@ -73,7 +73,9 @@ public class ChatListActivity extends Activity implements ChatListFragment.Callb
         sendGcmMessage("test 2");
         sendGcmMessage("test 3");
 
-        userProfileManager.getUserProfile(this, false);
+        if (!InstanceManager.userProfileRetrieved()) {
+            userProfileManager.getUserProfile(this);
+        }
     }
 
     @Override
@@ -81,7 +83,7 @@ public class ChatListActivity extends Activity implements ChatListFragment.Callb
         // check if we got here with the back button or with proper login result
         if (requestCode == resultCode) {
             // force profile reinitialize after login
-            userProfileManager.getUserProfile(this, true);
+            userProfileManager.getUserProfile(this);
         }
     }
 

--- a/app/src/main/java/com/nbusy/app/activities/ChatListFragment.java
+++ b/app/src/main/java/com/nbusy/app/activities/ChatListFragment.java
@@ -63,6 +63,8 @@ public class ChatListFragment extends ListFragment {
     public void onResume() {
         super.onResume();
         eventBus.register(this);
+
+        // user profile might be empty if this is the first time user is launching the app so we need this check
         if (InstanceManager.userProfileRetrieved()) {
             setData(InstanceManager.getUserProfile().getChats());
         }

--- a/app/src/main/java/com/nbusy/app/activities/LoginActivity.java
+++ b/app/src/main/java/com/nbusy/app/activities/LoginActivity.java
@@ -5,7 +5,6 @@ import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.View;
-import android.widget.Button;
 import android.widget.TextView;
 
 import com.google.android.gms.auth.api.Auth;
@@ -18,7 +17,6 @@ import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.common.api.Status;
 import com.nbusy.app.InstanceManager;
 import com.nbusy.app.R;
-import com.nbusy.app.Config;
 import com.nbusy.app.worker.GoogleAuthManager;
 
 /**
@@ -28,6 +26,7 @@ public class LoginActivity extends AppCompatActivity implements GoogleApiClient.
 
     private static final String TAG = LoginActivity.class.getSimpleName();
     private static final int RC_GET_TOKEN = 9002;
+    private final GoogleAuthManager googleAuthManager = InstanceManager.getGoogleAuthManager();
     private GoogleApiClient googleApiClient;
 
     private SignInButton signInButton;
@@ -84,7 +83,7 @@ public class LoginActivity extends AppCompatActivity implements GoogleApiClient.
             String idToken = acct.getIdToken();
 
             Log.d(TAG, "idToken: " + idToken);
-            InstanceManager.getGoogleAuthManager().login(idToken, new GoogleAuthManager.AuthFinishedCallback() {
+            googleAuthManager.login(idToken, new GoogleAuthManager.AuthFinishedCallback() {
                 @Override
                 public void success() {
                     setResult(GoogleAuthManager.LOGIN_OK);

--- a/app/src/main/java/com/nbusy/app/activities/LoginActivity.java
+++ b/app/src/main/java/com/nbusy/app/activities/LoginActivity.java
@@ -31,7 +31,6 @@ public class LoginActivity extends AppCompatActivity implements GoogleApiClient.
     private GoogleApiClient googleApiClient;
 
     private SignInButton signInButton;
-    private Button productionModeButton;
     private TextView statusTextView;
 
     @Override
@@ -42,14 +41,9 @@ public class LoginActivity extends AppCompatActivity implements GoogleApiClient.
         signInButton.setEnabled(true);
         statusTextView = (TextView) findViewById(R.id.status);
         statusTextView.setText("");
-        productionModeButton = (Button) findViewById(R.id.production_mode_button);
-        if (InstanceManager.getConfig().env != Config.Env.PRODUCTION) {
-            productionModeButton.setVisibility(View.VISIBLE);
-        }
 
         // Button click listeners
         signInButton.setOnClickListener(this);
-        productionModeButton.setOnClickListener(this);
 
         // Request only the user's ID token, which can be used to identify the user securely to your backend. This will contain the user's basic
         // profile (name, profile picture URL, etc) so you should not need to make an additional call to personalize your application.
@@ -125,10 +119,6 @@ public class LoginActivity extends AppCompatActivity implements GoogleApiClient.
                 statusTextView.setText(getString(R.string.logging_in));
                 getIdToken();
                 break;
-            case R.id.production_mode_button:
-                productionModeButton.setVisibility(View.GONE);
-                setProductionMode();
-                break;
         }
     }
 
@@ -138,10 +128,6 @@ public class LoginActivity extends AppCompatActivity implements GoogleApiClient.
         Intent signInIntent = Auth.GoogleSignInApi.getSignInIntent(googleApiClient);
         startActivityForResult(signInIntent, RC_GET_TOKEN);
         Log.d(TAG, "getIDToken: starting to get id token");
-    }
-
-    private void setProductionMode() {
-        InstanceManager.setConfig(new Config(Config.Env.PRODUCTION, null));
     }
 
     @Override

--- a/app/src/main/java/com/nbusy/app/services/DeviceBootBroadcastReceiver.java
+++ b/app/src/main/java/com/nbusy/app/services/DeviceBootBroadcastReceiver.java
@@ -10,6 +10,7 @@ public class DeviceBootBroadcastReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         if (intent.getAction().equals(Intent.ACTION_BOOT_COMPLETED)) {
+            // we need this check not to initiate service with null profile, before user logs in for the first time
             if (InstanceManager.userProfileRetrieved()) {
                 Intent serviceIntent = new Intent(context, ConnManagerService.class);
                 serviceIntent.putExtra(ConnManagerService.STARTED_BY, this.getClass().getSimpleName());

--- a/app/src/main/java/com/nbusy/app/worker/UserProfileManager.java
+++ b/app/src/main/java/com/nbusy/app/worker/UserProfileManager.java
@@ -47,7 +47,7 @@ public class UserProfileManager {
             public void success(UserProfile prof) {
                 Log.i(TAG, "user profile retrieved from DB, starting connection");
                 InstanceManager.setUserProfile(prof);
-                InstanceManager.getConnManager().ensureConn();
+                InstanceManager.getConnManager().ensureConn(); // we need this here since eventBus.register() skips .ensureConn() if user profile is empty
                 eventBus.post(new UserProfileRetrievedEvent(prof));
             }
 

--- a/app/src/main/java/com/nbusy/app/worker/UserProfileManager.java
+++ b/app/src/main/java/com/nbusy/app/worker/UserProfileManager.java
@@ -41,11 +41,7 @@ public class UserProfileManager {
     }
 
     // retrieves user profile and advertises availability of the user profile with an event
-    public void getUserProfile(final Activity activity, boolean force) {
-        if (!force && InstanceManager.userProfileRetrieved()) {
-            return;
-        }
-
+    public void getUserProfile(final Activity activity) {
         db.getProfile(new GetProfileCallback() {
             @Override
             public void success(UserProfile prof) {

--- a/app/src/main/java/neptulon/client/ConnImpl.java
+++ b/app/src/main/java/neptulon/client/ConnImpl.java
@@ -306,7 +306,7 @@ public class ConnImpl implements Conn, WebSocketListener {
     public void onFailure(IOException e, Response response) {
         state.set(State.DISCONNECTED);
         String reason = e.getMessage();
-        logger.info("Connection (or connection attempt) dropped to server: " + ws_url + ", reason: " + reason + ", exception: " + e);
+        logger.info("Connection (or connection attempt) dropped to server: " + ws_url + ", reason: " + e);
         reconnect(reason);
     }
 

--- a/app/src/main/java/neptulon/client/ConnImpl.java
+++ b/app/src/main/java/neptulon/client/ConnImpl.java
@@ -306,7 +306,7 @@ public class ConnImpl implements Conn, WebSocketListener {
     public void onFailure(IOException e, Response response) {
         state.set(State.DISCONNECTED);
         String reason = e.getMessage();
-        logger.info("Connection attempt failed, server: " + ws_url + ", reason: " + reason);
+        logger.info("Connection (or connection attempt) dropped to server: " + ws_url + ", reason: " + reason + ", exception: " + e);
         reconnect(reason);
     }
 

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -22,15 +22,6 @@
         android:layout_gravity="center_horizontal"
         android:layout_marginTop="25dp" />
 
-    <Button
-        android:id="@+id/production_mode_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_marginTop="25dp"
-        android:text="Production Mode"
-        android:visibility="gone" />
-
     <TextView
         android:id="@+id/status"
         android:layout_width="wrap_content"


### PR DESCRIPTION
* [x] Fixes: #121 'Login error' warning appears after successful login in production mode 
* [x] Fixes: #120 Remove 'Production Mode' button from login screen
* [x] Fixes: #119 Remove direct calls to InstanceManager as much as possible
* [x] Fixes: #87 Test no-connection during registration
* [x] Fixes: #124 Connection attempt failed after initial login
* [x] Fixes: #111 SQLDB.getQueuedMessages is being called 2x during startup after initial login