### PR TITLE
Simplify connection manager

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/app.iml
+++ b/app/app.iml
@@ -83,6 +83,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/builds" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
@@ -108,6 +109,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-support" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/reload-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/restart-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />

--- a/app/src/main/java/com/nbusy/app/InstanceManager.java
+++ b/app/src/main/java/com/nbusy/app/InstanceManager.java
@@ -61,7 +61,7 @@ public class InstanceManager extends Application {
 
     public static synchronized ConnManager getConnManager() {
         if (connManager == null) {
-            connManager = new ConnManager(getClient(), getEventBus(), getDB(), getUserProfile(), getAppContext(), getWorker());
+            connManager = new ConnManager(getClient(), getEventBus(), getDB(), getUserProfile(), getAppContext(), getWorker(), getConfig());
         }
 
         return connManager;

--- a/app/src/main/java/com/nbusy/app/data/sqldb/SQLDB.java
+++ b/app/src/main/java/com/nbusy/app/data/sqldb/SQLDB.java
@@ -29,7 +29,7 @@ import java.util.Objects;
 
 public class SQLDB implements DB {
 
-    // todo: do all sql operations in a single background thread and call cb
+    // todo: do all sql operations in a single background thread and call cb (as we do in titan with Executors.newSingleThreadExecutor())
 
     private static final String EQ_SEL = " = ?";
 

--- a/app/src/main/java/com/nbusy/app/services/ConnManagerService.java
+++ b/app/src/main/java/com/nbusy/app/services/ConnManagerService.java
@@ -22,33 +22,6 @@ public class ConnManagerService extends Service {
     private static final String TAG = ConnManagerService.class.getSimpleName();
     public static final String STARTED_BY = "StartedBy";
     public static final AtomicBoolean RUNNING = new AtomicBoolean();
-    private final StopStandby stopStandby = new StopStandby();
-    private int startId;
-    private final Config config = InstanceManager.getConfig();
-    private final Client client = InstanceManager.getClient();
-    private final ConnManager connManager = InstanceManager.getConnManager();
-
-    class StopStandby extends AsyncTask<Void, Void, Void> {
-        @Override
-        protected Void doInBackground(Void... params) {
-            // keep this service running, as long as we need an open connection to the server
-            while (connManager.needConnection()) {
-                try {
-                    Thread.sleep(config.standbyTime);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
-            }
-            return null;
-        }
-
-        @Override
-        protected void onPostExecute(Void result) {
-            if (!stopSelfResult(startId)) {
-                Log.e(TAG, "failed to stop service with startId: " + startId + " which did not match the one from the last start request");
-            }
-        }
-    }
 
     /*********************
      * Service Overrides *
@@ -61,18 +34,12 @@ public class ConnManagerService extends Service {
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
-        this.startId = startId;
-
         if (intent != null) {
             String startedBy = intent.getStringExtra(STARTED_BY);
             Log.i(TAG, "Started by: " + startedBy);
         } else {
             // service is restarted by Android system after a termination so intent will be null in this case
             Log.i(TAG, "Restarted by Android system after termination.");
-        }
-
-        if (stopStandby.getStatus() != AsyncTask.Status.RUNNING) {
-            stopStandby.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
         }
 
         ConnManagerService.RUNNING.set(true);
@@ -84,7 +51,6 @@ public class ConnManagerService extends Service {
     @Override
     public void onDestroy() {
         super.onDestroy();
-        client.close();
         RUNNING.set(false);
         Log.i(TAG, "destroyed");
     }

--- a/app/src/main/java/com/nbusy/app/services/ConnManagerService.java
+++ b/app/src/main/java/com/nbusy/app/services/ConnManagerService.java
@@ -2,20 +2,16 @@ package com.nbusy.app.services;
 
 import android.app.Service;
 import android.content.Intent;
-import android.os.AsyncTask;
 import android.os.IBinder;
 import android.support.annotation.Nullable;
 import android.util.Log;
 
-import com.nbusy.app.InstanceManager;
-import com.nbusy.app.Config;
 import com.nbusy.app.worker.ConnManager;
-import com.nbusy.sdk.Client;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * Hosts {@link ConnManager} class to ensure continuous operation even when no activity is visible.
+ * Keeps the app alive until stopped by the {@link ConnManager}.
  */
 public class ConnManagerService extends Service {
 

--- a/app/src/main/java/com/nbusy/app/services/DeviceBootBroadcastReceiver.java
+++ b/app/src/main/java/com/nbusy/app/services/DeviceBootBroadcastReceiver.java
@@ -10,8 +10,8 @@ public class DeviceBootBroadcastReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         if (intent.getAction().equals(Intent.ACTION_BOOT_COMPLETED)) {
-            // todo: retrieve user profile, make sure that the user logged in and have a JWT token, then start connection manager service
-//            InstanceManager.getUserProfileManager().getUserProfile(() => InstanceManager.getConnManager().ensureConn(this.getClass().getSimpleName()));
+            // retrieve user profile, which will start connection manager in return, which will start the connection manager service in return
+            InstanceManager.getUserProfileManager().getUserProfile(null);
 
             // todo: use WakefulBroadcastReceiver.startWakefulService() instead to make sure that device does not sleep while service is running?
 //            /**

--- a/app/src/main/java/com/nbusy/app/services/DeviceBootBroadcastReceiver.java
+++ b/app/src/main/java/com/nbusy/app/services/DeviceBootBroadcastReceiver.java
@@ -10,14 +10,8 @@ public class DeviceBootBroadcastReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         if (intent.getAction().equals(Intent.ACTION_BOOT_COMPLETED)) {
-            // we need this check not to initiate service with null profile, before user logs in for the first time
-            if (InstanceManager.userProfileRetrieved()) {
-                Intent serviceIntent = new Intent(context, ConnManagerService.class);
-                serviceIntent.putExtra(ConnManagerService.STARTED_BY, this.getClass().getSimpleName());
-                context.startService(serviceIntent);
-            } else {
-                // todo: retrieve user profile then start connection manager service
-            }
+            // todo: retrieve user profile, make sure that the user logged in and have a JWT token, then start connection manager service
+//            InstanceManager.getUserProfileManager().getUserProfile(() => InstanceManager.getConnManager().ensureConn(this.getClass().getSimpleName()));
 
             // todo: use WakefulBroadcastReceiver.startWakefulService() instead to make sure that device does not sleep while service is running?
 //            /**

--- a/app/src/main/java/com/nbusy/app/worker/ConnManager.java
+++ b/app/src/main/java/com/nbusy/app/worker/ConnManager.java
@@ -74,8 +74,9 @@ public class ConnManager implements ConnCallbacks {
 
     /**
      * Starts/restarts connection sequence to NBusy servers if we are not connected.
+     * @param requestedBy - If provided, this will be used in logs as the initiator of the connection manager service.
      */
-    public void ensureConn() {
+    public void ensureConn(String requestedBy) {
         if (!client.isConnected()) {
             client.connect(this);
         }
@@ -83,7 +84,7 @@ public class ConnManager implements ConnCallbacks {
         // start the connection manager service if not running
         if (!ConnManagerService.RUNNING.getAndSet(true)) {
             Intent serviceIntent = new Intent(appContext, ConnManagerService.class);
-            serviceIntent.putExtra(ConnManagerService.STARTED_BY, this.getClass().getSimpleName());
+            serviceIntent.putExtra(ConnManagerService.STARTED_BY, this.getClass().getSimpleName() + ", upon request by: " + requestedBy);
             appContext.startService(serviceIntent);
         }
     }

--- a/app/src/main/java/com/nbusy/app/worker/ConnManager.java
+++ b/app/src/main/java/com/nbusy/app/worker/ConnManager.java
@@ -93,8 +93,6 @@ public class ConnManager implements ConnCallbacks {
 
         @Override
         protected void onPostExecute(Void result) {
-            // todo: someone might call ensureConn before service is stopped and service might stop when it should be running
-            //       block calls to ensureConn (or user a timer) until service is verified closed on STOPPING state
             appContext.stopService(new Intent(appContext, ConnManagerService.class));
             client.close();
         }
@@ -109,10 +107,9 @@ public class ConnManager implements ConnCallbacks {
 
     /**
      * Starts/restarts connection sequence to NBusy servers if we are not connected.
-     *
      * @param requestedBy - If provided, this will be used in logs as the initiator of the connection manager service.
      */
-    public void ensureConn(String requestedBy) {
+    public synchronized void ensureConn(String requestedBy) {
         if (!client.isConnected()) {
             client.connect(this);
         }

--- a/app/src/main/java/com/nbusy/app/worker/ConnManager.java
+++ b/app/src/main/java/com/nbusy/app/worker/ConnManager.java
@@ -81,7 +81,9 @@ public class ConnManager implements ConnCallbacks {
         @Override
         protected Void doInBackground(Void... params) {
             // keep this service running, as long as we need an open connection to the server
-            while (needConnection()) {
+            boolean firstTime = true;
+            while (needConnection() || firstTime) {
+                firstTime = false;
                 while (needConnection()) {
                     try {
                         Thread.sleep(config.standbyTime / 2);
@@ -111,7 +113,7 @@ public class ConnManager implements ConnCallbacks {
      * Whether we need an active connection to server.
      */
     public boolean needConnection() {
-        return eventBus.haveSubscribers() || client.haveOngoingRequests();
+        return eventBus.haveSubscribers() || client.haveOngoingRequests(); // todo: || client.state() == connecting ...
     }
 
     /**

--- a/app/src/main/java/com/nbusy/app/worker/ConnManager.java
+++ b/app/src/main/java/com/nbusy/app/worker/ConnManager.java
@@ -82,8 +82,17 @@ public class ConnManager implements ConnCallbacks {
         protected Void doInBackground(Void... params) {
             // keep this service running, as long as we need an open connection to the server
             while (needConnection()) {
+                while (needConnection()) {
+                    try {
+                        Thread.sleep(config.standbyTime / 2);
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                }
+
+                // check-wait-check cycle
                 try {
-                    Thread.sleep(config.standbyTime);
+                    Thread.sleep(config.standbyTime / 2);
                 } catch (InterruptedException e) {
                     e.printStackTrace();
                 }

--- a/app/src/main/java/com/nbusy/app/worker/ConnManager.java
+++ b/app/src/main/java/com/nbusy/app/worker/ConnManager.java
@@ -113,7 +113,7 @@ public class ConnManager implements ConnCallbacks {
      * Whether we need an active connection to server.
      */
     public boolean needConnection() {
-        return eventBus.haveSubscribers() || client.haveOngoingRequests(); // todo: || client.state() == connecting ...
+        return eventBus.haveSubscribers() || client.haveOngoingRequests();
     }
 
     /**

--- a/app/src/main/java/com/nbusy/app/worker/ConnManager.java
+++ b/app/src/main/java/com/nbusy/app/worker/ConnManager.java
@@ -118,6 +118,10 @@ public class ConnManager implements ConnCallbacks {
 
     /**
      * Starts/restarts connection sequence to NBusy servers if we are not connected.
+     *
+     * Called by: EventBus.register() (except when user profile is empty)
+     * Called by: UserProfileManager.getUserProfile() (since eventBus.register() skips .ensureConn() if user profile is empty)
+     *
      * @param requestedBy - If provided, this will be used in logs as the initiator of the connection manager service.
      */
     public synchronized void ensureConn(String requestedBy) {

--- a/app/src/main/java/com/nbusy/app/worker/UserProfileManager.java
+++ b/app/src/main/java/com/nbusy/app/worker/UserProfileManager.java
@@ -42,12 +42,16 @@ public class UserProfileManager {
 
     // retrieves user profile and advertises availability of the user profile with an event
     public void getUserProfile(final Activity activity) {
+        if (activity == null) {
+            throw new IllegalArgumentException("activity cannot be null");
+        }
+
         db.getProfile(new GetProfileCallback() {
             @Override
             public void success(UserProfile prof) {
                 Log.i(TAG, "user profile retrieved from DB, starting connection");
                 InstanceManager.setUserProfile(prof);
-                InstanceManager.getConnManager().ensureConn(); // we need this here since eventBus.register() skips .ensureConn() if user profile is empty
+                InstanceManager.getConnManager().ensureConn(this.getClass().getSimpleName()); // we need this here since eventBus.register() skips .ensureConn() if user profile is empty
                 eventBus.post(new UserProfileRetrievedEvent(prof));
             }
 

--- a/app/src/main/java/com/nbusy/app/worker/UserProfileManager.java
+++ b/app/src/main/java/com/nbusy/app/worker/UserProfileManager.java
@@ -42,7 +42,7 @@ public class UserProfileManager {
 
     /**
      * Retrieves user profile and advertises availability of the user profile with an event.
-     * @param activity - If provided, current activity will be redirected to login activity and back, if user profile does not exist.
+     * @param activity - (optional) If provided, current activity will be redirected to login activity and back, if user profile does not exist.
      */
     public void getUserProfile(final Activity activity) {
         db.getProfile(new GetProfileCallback() {

--- a/app/src/main/java/com/nbusy/app/worker/UserProfileManager.java
+++ b/app/src/main/java/com/nbusy/app/worker/UserProfileManager.java
@@ -40,12 +40,11 @@ public class UserProfileManager {
         this.db = db;
     }
 
-    // retrieves user profile and advertises availability of the user profile with an event
+    /**
+     * Retrieves user profile and advertises availability of the user profile with an event.
+     * @param activity - If provided, current activity will be redirected to login activity and back, if user profile does not exist.
+     */
     public void getUserProfile(final Activity activity) {
-        if (activity == null) {
-            throw new IllegalArgumentException("activity cannot be null");
-        }
-
         db.getProfile(new GetProfileCallback() {
             @Override
             public void success(UserProfile prof) {
@@ -57,6 +56,9 @@ public class UserProfileManager {
 
             @Override
             public void error() {
+                if (activity == null) {
+                    return;
+                }
                 Log.i(TAG, "user profile does not exist in DB, starting login activity");
                 Intent intent = new Intent(activity, LoginActivity.class);
                 activity.startActivityForResult(intent, GoogleAuthManager.LOGIN_OK);

--- a/app/src/main/java/com/nbusy/app/worker/eventbus/EventBus.java
+++ b/app/src/main/java/com/nbusy/app/worker/eventbus/EventBus.java
@@ -25,7 +25,7 @@ public class EventBus extends com.google.common.eventbus.AsyncEventBus {
 
         // a view is attaching to event bus so we need to ensure connectivity
         if (InstanceManager.userProfileRetrieved()) {
-            InstanceManager.getConnManager().ensureConn();
+            InstanceManager.getConnManager().ensureConn(this.getClass().getSimpleName());
         }
 
         if (subscribers.contains(o)) {

--- a/app/src/main/java/neptulon/client/ConnImpl.java
+++ b/app/src/main/java/neptulon/client/ConnImpl.java
@@ -44,6 +44,7 @@ import okio.Buffer;
 
 /**
  * Neptulon connection implementation: https://github.com/neptulon/neptulon
+ * All methods in this class is thread safe.
  */
 public class ConnImpl implements Conn, WebSocketListener {
     private static final Logger logger = Logger.getLogger("Neptulon: " + ConnImpl.class.getSimpleName());

--- a/app/src/main/java/neptulon/client/ConnImpl.java
+++ b/app/src/main/java/neptulon/client/ConnImpl.java
@@ -77,7 +77,8 @@ public class ConnImpl implements Conn, WebSocketListener {
         }
     }
 
-    public enum State {
+    // connection state
+    private enum State {
         CONNECTING,
         CONNECTED,
         DISCONNECTED,

--- a/app/src/main/java/titan/client/ClientImpl.java
+++ b/app/src/main/java/titan/client/ClientImpl.java
@@ -21,6 +21,7 @@ import titan.client.responses.GoogleAuthResponse;
 
 /**
  * Titan client implementation: https://github.com/titan-x/titan
+ * All methods in this class is thread safe.
  */
 public class ClientImpl implements Client {
     private static final Logger logger = Logger.getLogger("Titan: " + ClientImpl.class.getSimpleName());


### PR DESCRIPTION
* [x] ConnManagerService lifecycle is now only controller by ConnManager;
* [x] Fixes #132 - Move ConnManagerService logic into ConnManager.
* [x] Fixes #107 - ConnManager.ensureConn and needConn should only be called by ConnManagerService or whatever the entry point is (i.e. eventbus).
* [x] Fixes #90 - ConnManager should manage all client connection lifecycle.
